### PR TITLE
Update_test_weather_hash_and_Faraday_client_exlude

### DIFF
--- a/lib/get_weather.rb
+++ b/lib/get_weather.rb
@@ -40,7 +40,7 @@ Weather for Lat: #{$LAT}, Long: #{$LONG}: #{@temp}ºF, #{@description}
   end
 
   def self.get_weather(output: $stdout, client: faraday_client, forecast: forecast_passed)
-    response = client.get("/data/2.5/onecall?lat=#{$LAT}&lon=#{$LONG}&appid=#{$APPID}")
+    response = client.get("/data/2.5/onecall?lat=#{$LAT}&lon=#{$LONG}&exclude=hourly,minutely&appid=#{$APPID}")
     if response.success?
       weather_hash = JSON.parse(response.body)
       weather = Weather.new()

--- a/test/get_weather_test.rb
+++ b/test/get_weather_test.rb
@@ -6,26 +6,79 @@ require "stringio"
 class GetWeatherTest < Minitest::Test
   def canned_weather_hash
     {
+      "lat" => 41.936748,
+      "lon" => -88.069309,
+      "timezone" => "America/Chicago",
+      "timezone_offset" => -21600,
       "current" => {
+        "dt" => 1595243443,
+        "sunrise" => 1608124431,
+        "sunset" => 1608160224,
         "temp" => "10",
+        "feels_like" => 270.4,
+        "pressure" => 1017,
+        "humidity" => 96,
+        "dew_point" => 274.18,
+        "uvi" => 0,
+        "clouds" => 90,
+        "visibility" => 6437,
+        "wind_speed" => 3.6,
+        "wind_deg" => 320,
         "weather" => [
           {
-            "description" => "Blizzard"
+            "id" => 701,
+            "main" => "Mist",
+            "description": "mist",
+            "icon" => "50n"
           }
         ]
       },
       "daily" => [
         {
+          "dt" => 1595268000,
+          "sunrise" => 1608124431,
+          "sunset" => 1608160224,
           "temp" => {
-            "day" => "2"
-            },
+            "day" => "2",
+            "min" => 273.15,
+            "max" => 279.4,
+            "night": 273.15,
+            "eve": 275.82,
+            "morn": 275.35
+          },
+          "feels_like" => {
+            "day" => 273.53,
+            "night": 270.26,
+            "eve": 271.89,
+            "morn": 272.11
+          },
+          "pressure": 1021,
+          "humidity": 70,
+          "dew_point": 273.27,
+          "wind_speed": 3.74,
+          "wind_deg": 323,
           "weather" => [
             {
-              "description" => "Snow"
+              "id": 803,
+              "main": "Clouds",
+              "description": "broken clouds",
+              "icon": "04d"
             }
-          ]
+          ],
+          "clouds": 60,
+          "pop": 0.84,
+          "uvi": 2.41
         }
-      ]
+      ],
+      "alerts": [
+          {
+            "sender_name": "NWS Tulsa (Eastern Oklahoma)",
+            "event": "Heat Advisory",
+            "start": 1597341600,
+            "end": 1597366800,
+            "description": "...HEAT ADVISORY REMAINS IN EFFECT FROM 1 PM THIS AFTERNOON TO\n8 PM CDT THIS EVENING...\n* WHAT...Heat index values of 105 to 109 degrees expected.\n* WHERE...Creek, Okfuskee, Okmulgee, McIntosh, Pittsburg,\nLatimer, Pushmataha, and Choctaw Counties.\n* WHEN...From 1 PM to 8 PM CDT Thursday.\n* IMPACTS...The combination of hot temperatures and high\nhumidity will combine to create a dangerous situation in which\nheat illnesses are possible."
+          }
+        ]
     }
   end
 
@@ -63,7 +116,7 @@ class GetWeatherTest < Minitest::Test
     forecast = "daily"
     GetWeather.get_weather(output: output, client: client, forecast: forecast)   
     output.rewind
-    expected = "Weather for Lat: 41.936748, Long: -88.069309: 2ºF, Snow"
+    expected = "Weather for Lat: 41.936748, Long: -88.069309: 2ºF, broken clouds"
     assert_equal expected, output.read.chomp
   end
 
@@ -75,7 +128,7 @@ class GetWeatherTest < Minitest::Test
     forecast = "current"
     GetWeather.get_weather(output: output, client: client, forecast: forecast)   
     output.rewind
-    expected = "Weather for Lat: 41.936748, Long: -88.069309: 10ºF, Blizzard"
+    expected = "Weather for Lat: 41.936748, Long: -88.069309: 10ºF, mist"
     assert_equal expected, output.read.chomp
   end
 


### PR DESCRIPTION
Updated canned_weather_hash in get_weather_test.rb for more accuracy for future features

Update URL extension  (response variable -- line 43) in get_weather.rb to exclude minutely and hourly data for hash. Not needed for future features as of yet.